### PR TITLE
Reuse DISPLAY if set and invoke grep once

### DIFF
--- a/Windows/Windows Subsystem for Linux/README.md
+++ b/Windows/Windows Subsystem for Linux/README.md
@@ -186,7 +186,7 @@ wsl --set-version <distro> <version>
    1. Append to your `~/.bashrc`:
 
       ```sh
-      export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0
+      export DISPLAY=${DISPLAY:-$(grep -Po '(?<=nameserver ).*' /etc/resolv.conf):0}
       export LIBGL_ALWAYS_INDIRECT=1
       ```
 


### PR DESCRIPTION
We can safely reuse the `DISPLAY` environment variable if it's already set instead of recomputing the same value again. Also replaced the `cat` + `grep` + `awk` chain with a single `grep` invocation to speed up startup further.